### PR TITLE
[Fix]: Docker 이미지 latest 태그를 구체적 버전으로 고정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - git-ranker-net
 
   prometheus:
-    image: prom/prometheus:v3.2.1
+    image: prom/prometheus:v3.5.1
     container_name: git-ranker-prometheus
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## 📌 개요

`docker-compose.yml`에서 모니터링 스택(Prometheus, Loki, Promtail, Grafana) 이미지의 `latest` 태그를 구체적 버전으로 고정하여 배포 재현성을 확보합니다.

## 🔗 관련 이슈

closes #30

## 🛠 작업 내용

### Docker 이미지 버전 고정

`latest` 태그 사용 시 `docker compose pull` 시점에 따라 다른 버전이 내려와 Breaking Change 위험이 있습니다. 4개 서비스 모두 안정된 구체적 버전으로 고정했습니다.

| 서비스 | Before | After |
|--------|--------|-------|
| prometheus | `prom/prometheus:latest` | `prom/prometheus:v3.5.1` |
| loki | `grafana/loki:latest` | `grafana/loki:3.6.5` |
| promtail | `grafana/promtail:latest` | `grafana/promtail:3.6.5` |
| grafana | `grafana/grafana:latest` | `grafana/grafana:12.3.2` |

> Loki와 Promtail은 프로토콜 호환성을 위해 반드시 동일 버전을 사용해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기타 (Chores)**
  * Prometheus, Loki, Promtail, Grafana 컨테이너 이미지를 자동 업데이트(latest)에서 특정 버전으로 고정했습니다. (Prometheus: v3.5.1, Loki: 3.6.5, Promtail: 3.6.5, Grafana: 12.3.2) 배포 시 더 안정적이고 예측 가능한 런타임 환경을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->