### PR TITLE
[Feat]: 운영 모니터링 대시보드 전면 재설계

### DIFF
--- a/dashboards/git-ranker-dashboard.json
+++ b/dashboards/git-ranker-dashboard.json
@@ -652,32 +652,32 @@
         "type": "datasource"
       },
       {
-        "current": { "selected": false, "text": "", "value": "" },
+        "current": { "selected": false, "text": "enter-trace-id", "value": "enter-trace-id" },
         "hide": 0,
         "label": "Trace ID",
         "name": "trace_id",
-        "options": [{ "selected": true, "text": "", "value": "" }],
-        "query": "",
+        "options": [{ "selected": true, "text": "enter-trace-id", "value": "enter-trace-id" }],
+        "query": "enter-trace-id",
         "skipUrlSync": false,
         "type": "textbox"
       },
       {
-        "current": { "selected": false, "text": "", "value": "" },
+        "current": { "selected": false, "text": "enter-username", "value": "enter-username" },
         "hide": 0,
         "label": "Username",
         "name": "username_search",
-        "options": [{ "selected": true, "text": "", "value": "" }],
-        "query": "",
+        "options": [{ "selected": true, "text": "enter-username", "value": "enter-username" }],
+        "query": "enter-username",
         "skipUrlSync": false,
         "type": "textbox"
       },
       {
-        "current": { "selected": false, "text": "", "value": "" },
+        "current": { "selected": false, "text": "enter-ip-address", "value": "enter-ip-address" },
         "hide": 0,
         "label": "IP Address",
         "name": "ip_search",
-        "options": [{ "selected": true, "text": "", "value": "" }],
-        "query": "",
+        "options": [{ "selected": true, "text": "enter-ip-address", "value": "enter-ip-address" }],
+        "query": "enter-ip-address",
         "skipUrlSync": false,
         "type": "textbox"
       }


### PR DESCRIPTION
## 📌 개요

Loki 기반 비즈니스 메트릭 쿼리를 Prometheus 카운터로 전환하고, 운영에 필요한 에러 분석/사용자 추적/이탈 분석 패널을 추가하여 대시보드를 전면 재설계합니다.

## 🔗 관련 이슈

closes #40

## 🛠 작업 내용

### dashboards/git-ranker-dashboard.json

**쿼리 전환 (Loki → Prometheus)**
- User Metrics 6개 stat 패널: `count_over_time()` → `increase(counter[$__range])`
- GitHub API Call Volume, Success Rate: Loki → Prometheus
- Batch Completed/Failed: Loki → Prometheus

**신규 패널 추가**
- User Metrics: Manual Refreshes, Account Deletions stat (이탈 분석)
- User Activity Trend: Deletions 시계열 추가
- GitHub API: API Latency P95 패널
- Batch Jobs: Items Processed/Skipped stat, `log_category="BATCH"` 필터
- Error Analysis 행 신설: Error by Code (bar), Error Trend (시계열), Auth Failures 401/403
- Log Search 행 추가 (collapsed): Trace ID / Username / IP 기반 로그 검색

**인프라 개선**
- 모든 datasource UID를 변수화: `${prometheus_ds}`, `${loki_ds}`
- 대시보드 변수 5개 추가: `prometheus_ds`, `loki_ds`, `trace_id`, `username_search`, `ip_search`
- 자동 새로고침 기본값 OFF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * Prometheus/Loki 선택기 등 데이터 소스 템플릿 추가
  * 추적 ID, 사용자명, IP로 필터링 가능한 검색 필드 및 향상된 로그/트레이스 검색 패널 추가
  * 등록·로그인·새로고침·삭제·오류·인증 실패 등 KPI 패널 추가

* **변경**
  * 대시보드 레이아웃 재구성 및 패널 재배치, 신규 시각화(타임시리즈·게이지·파이) 추가
  * 새 태그와 메타데이터 업데이트, 대시보드 버전 상승
<!-- end of auto-generated comment: release notes by coderabbit.ai -->