### PR TITLE
[Feat]: 운영 알림 규칙 보강

### DIFF
--- a/alerting/alert-rules.yml
+++ b/alerting/alert-rules.yml
@@ -89,6 +89,107 @@ groups:
         labels:
           severity: critical
 
+      - uid: high-latency-p99
+        title: High P99 Latency
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{application="git-ranker-api"}[5m])) by (le)) * 1000
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              expression: A
+              reducer: last
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              expression: $B > 5000
+              type: math
+        dashboardUid: git-ranker-ops
+        panelId: 3
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: P99 latency exceeds 5 seconds
+          description: "P99 response time: {{ $values.B.Value }}ms"
+        labels:
+          severity: warning
+
+      - uid: db-connection-pool-high
+        title: DB Connection Pool Usage High
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: hikaricp_connections_active{application="git-ranker-api"} / hikaricp_connections_max{application="git-ranker-api"}
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              expression: A
+              reducer: last
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              expression: $B > 0.8
+              type: math
+        noDataState: OK
+        execErrState: OK
+        for: 3m
+        annotations:
+          summary: HikariCP connection pool usage exceeds 80%
+          description: "Connection pool usage: {{ $values.B.Value }}"
+        labels:
+          severity: warning
+
+      - uid: jvm-heap-high
+        title: JVM Heap Memory Usage High
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: sum(jvm_memory_used_bytes{application="git-ranker-api", area="heap"}) / sum(jvm_memory_max_bytes{application="git-ranker-api", area="heap"})
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              expression: A
+              reducer: last
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              expression: $B > 0.85
+              type: math
+        noDataState: OK
+        execErrState: OK
+        for: 5m
+        annotations:
+          summary: JVM heap memory usage exceeds 85%
+          description: "Heap usage ratio: {{ $values.B.Value }}"
+        labels:
+          severity: warning
+
   - orgId: 1
     name: GitHub API
     folder: Git Ranker Alerts
@@ -166,6 +267,41 @@ groups:
         annotations:
           summary: Error logs detected
           description: "Error logs count (last 1m): {{ $values.B.Value }}"
+        labels:
+          severity: warning
+
+      - uid: error-spike
+        title: Application Error Spike
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: sum(increase(errors_total{application="git-ranker-api"}[5m]))
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              expression: A
+              reducer: last
+              type: reduce
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              expression: $B > 10
+              type: math
+        dashboardUid: git-ranker-ops
+        panelId: 50
+        noDataState: OK
+        execErrState: OK
+        for: 2m
+        annotations:
+          summary: Sudden increase in application errors
+          description: "Errors in last 5 minutes: {{ $values.B.Value }}"
         labels:
           severity: warning
 


### PR DESCRIPTION
## 📌 개요

Prometheus 메트릭 기반 알림 4개를 추가하여 성능 저하, 리소스 고갈, 에러 급증을 사전에 감지합니다.

## 🔗 관련 이슈

closes #42

## 🛠 작업 내용

### alerting/alert-rules.yml

**System Health 그룹 (3개 추가)**
- `high-latency-p99`: P99 응답 시간 > 5000ms, 5분 지속 시 warning
- `db-connection-pool-high`: HikariCP active/max > 80%, 3분 지속 시 warning
- `jvm-heap-high`: JVM heap used/max > 85%, 5분 지속 시 warning

**Application Errors 그룹 (1개 추가)**
- `error-spike`: `errors_total` 5분 내 10건 초과, 2분 지속 시 warning