### PR TITLE
[Feat]: 서비스 레이어 단위 테스트 추가

### DIFF
--- a/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java
+++ b/src/test/java/com/gitranker/api/batch/processor/ScoreRecalculationProcessorTest.java
@@ -1,0 +1,135 @@
+package com.gitranker.api.batch.processor;
+
+import com.gitranker.api.batch.strategy.FullActivityUpdateStrategy;
+import com.gitranker.api.batch.strategy.IncrementalActivityUpdateStrategy;
+import com.gitranker.api.domain.log.ActivityLog;
+import com.gitranker.api.domain.log.ActivityLogRepository;
+import com.gitranker.api.domain.log.ActivityLogService;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.domain.user.vo.ActivityStatistics;
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.BusinessException;
+import com.gitranker.api.global.error.exception.GitHubApiNonRetryableException;
+import com.gitranker.api.global.error.exception.GitHubApiRetryableException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScoreRecalculationProcessorTest {
+
+    @InjectMocks
+    private ScoreRecalculationProcessor processor;
+
+    @Mock private ActivityLogRepository activityLogRepository;
+    @Mock private ActivityLogService activityLogService;
+    @Mock private IncrementalActivityUpdateStrategy incrementalStrategy;
+    @Mock private FullActivityUpdateStrategy fullStrategy;
+
+    private User createUser() {
+        return User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("이전 기준 로그가 없으면 Full 전략을 선택한다")
+    void should_selectFullStrategy_when_noBaselineLog() {
+        User user = createUser();
+        ActivityStatistics stats = ActivityStatistics.of(10, 2, 1, 0, 3);
+
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(activityLogRepository.findTopByUserAndActivityDateLessThanOrderByActivityDateDesc(eq(user), any()))
+                .thenReturn(Optional.empty());
+        when(fullStrategy.update(eq(user), any())).thenReturn(stats);
+
+        User result = processor.process(user);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalScore()).isGreaterThan(0);
+        verify(fullStrategy).update(eq(user), any());
+        verify(incrementalStrategy, never()).update(any(), any());
+    }
+
+    @Test
+    @DisplayName("이전 기준 로그가 있으면 Incremental 전략을 선택한다")
+    void should_selectIncrementalStrategy_when_baselineLogExists() {
+        User user = createUser();
+        ActivityStatistics stats = ActivityStatistics.of(10, 2, 1, 0, 3);
+        ActivityLog baselineLog = ActivityLog.empty(user, LocalDate.of(2024, 12, 31));
+
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(activityLogRepository.findTopByUserAndActivityDateLessThanOrderByActivityDateDesc(eq(user), any()))
+                .thenReturn(Optional.of(baselineLog));
+        when(incrementalStrategy.update(eq(user), any())).thenReturn(stats);
+
+        User result = processor.process(user);
+
+        assertThat(result).isNotNull();
+        verify(incrementalStrategy).update(eq(user), any());
+        verify(fullStrategy, never()).update(any(), any());
+    }
+
+    @Test
+    @DisplayName("GitHubApiRetryableException은 그대로 전파된다")
+    void should_rethrowRetryableException() {
+        User user = createUser();
+
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(activityLogRepository.findTopByUserAndActivityDateLessThanOrderByActivityDateDesc(eq(user), any()))
+                .thenReturn(Optional.empty());
+        when(fullStrategy.update(eq(user), any()))
+                .thenThrow(new GitHubApiRetryableException(ErrorType.GITHUB_API_TIMEOUT));
+
+        assertThatThrownBy(() -> processor.process(user))
+                .isInstanceOf(GitHubApiRetryableException.class);
+    }
+
+    @Test
+    @DisplayName("GitHubApiNonRetryableException은 그대로 전파된다")
+    void should_rethrowNonRetryableException() {
+        User user = createUser();
+
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(activityLogRepository.findTopByUserAndActivityDateLessThanOrderByActivityDateDesc(eq(user), any()))
+                .thenReturn(Optional.empty());
+        when(fullStrategy.update(eq(user), any()))
+                .thenThrow(new GitHubApiNonRetryableException(ErrorType.GITHUB_USER_NOT_FOUND));
+
+        assertThatThrownBy(() -> processor.process(user))
+                .isInstanceOf(GitHubApiNonRetryableException.class);
+    }
+
+    @Test
+    @DisplayName("기타 예외는 BusinessException으로 감싸서 전파된다")
+    void should_wrapInBusinessException_when_unexpectedError() {
+        User user = createUser();
+
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(activityLogRepository.findTopByUserAndActivityDateLessThanOrderByActivityDateDesc(eq(user), any()))
+                .thenReturn(Optional.empty());
+        when(fullStrategy.update(eq(user), any()))
+                .thenThrow(new RuntimeException("unexpected"));
+
+        assertThatThrownBy(() -> processor.process(user))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,193 @@
+package com.gitranker.api.domain.auth.service;
+
+import com.gitranker.api.domain.auth.RefreshToken;
+import com.gitranker.api.domain.auth.RefreshTokenRepository;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.global.auth.AuthCookieManager;
+import com.gitranker.api.global.auth.jwt.JwtProvider;
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private AuthCookieManager authCookieManager;
+
+    private RefreshToken createValidRefreshToken(User user) {
+        return RefreshToken.builder()
+                .token("valid-token")
+                .user(user)
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+    }
+
+    private RefreshToken createExpiredRefreshToken(User user) {
+        return RefreshToken.builder()
+                .token("expired-token")
+                .user(user)
+                .expiresAt(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("refreshAccessToken")
+    class RefreshAccessToken {
+
+        @Test
+        @DisplayName("유효한 토큰이면 새 Access/Refresh 토큰을 발급한다")
+        void should_issueNewTokens_when_validRefreshToken() {
+            User user = mock(User.class);
+            when(user.getUsername()).thenReturn("testuser");
+            when(user.getRole()).thenReturn(Role.USER);
+            RefreshToken refreshToken = createValidRefreshToken(user);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            when(refreshTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(refreshToken));
+            when(jwtProvider.createAccessToken("testuser", Role.USER)).thenReturn("new-access-token");
+            when(refreshTokenService.issueRefreshToken(user)).thenReturn("new-refresh-token");
+
+            authService.refreshAccessToken("valid-token", response);
+
+            verify(authCookieManager).addAccessTokenCookie(response, "new-access-token");
+            verify(authCookieManager).addRefreshTokenCookie(response, "new-refresh-token");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 토큰이면 INVALID_REFRESH_TOKEN 예외가 발생한다")
+        void should_throwInvalidToken_when_tokenNotFound() {
+            when(refreshTokenRepository.findByToken("unknown")).thenReturn(Optional.empty());
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            assertThatThrownBy(() -> authService.refreshAccessToken("unknown", response))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                            .isEqualTo(ErrorType.INVALID_REFRESH_TOKEN));
+        }
+
+        @Test
+        @DisplayName("만료된 토큰이면 삭제 후 EXPIRED_REFRESH_TOKEN 예외가 발생한다")
+        void should_deleteAndThrow_when_tokenExpired() {
+            User user = mock(User.class);
+            RefreshToken expiredToken = createExpiredRefreshToken(user);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            when(refreshTokenRepository.findByToken("expired-token")).thenReturn(Optional.of(expiredToken));
+
+            assertThatThrownBy(() -> authService.refreshAccessToken("expired-token", response))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                            .isEqualTo(ErrorType.EXPIRED_REFRESH_TOKEN));
+
+            verify(refreshTokenRepository).delete(expiredToken);
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    class Logout {
+
+        @Test
+        @DisplayName("본인의 토큰으로 로그아웃하면 토큰을 삭제하고 쿠키를 정리한다")
+        void should_deleteTokenAndClearCookies_when_validLogout() {
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(1L);
+            when(user.getUsername()).thenReturn("testuser");
+            RefreshToken refreshToken = createValidRefreshToken(user);
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            when(refreshTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(refreshToken));
+            when(request.getSession(false)).thenReturn(null);
+
+            authService.logout(user, "valid-token", request, response);
+
+            verify(refreshTokenRepository).deleteByToken("valid-token");
+            verify(authCookieManager).clearAccessTokenCookie(response);
+            verify(authCookieManager).clearRefreshTokenCookie(response);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 토큰으로 로그아웃하면 FORBIDDEN 예외가 발생한다")
+        void should_throwForbidden_when_logoutWithOtherUsersToken() {
+            User currentUser = mock(User.class);
+            when(currentUser.getId()).thenReturn(1L);
+            User otherUser = mock(User.class);
+            when(otherUser.getId()).thenReturn(2L);
+            RefreshToken otherToken = createValidRefreshToken(otherUser);
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            when(refreshTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(otherToken));
+
+            assertThatThrownBy(() -> authService.logout(currentUser, "valid-token", request, response))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                            .isEqualTo(ErrorType.FORBIDDEN));
+        }
+
+        @Test
+        @DisplayName("세션이 있으면 무효화한다")
+        void should_invalidateSession_when_sessionExists() {
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(1L);
+            when(user.getUsername()).thenReturn("testuser");
+            RefreshToken refreshToken = createValidRefreshToken(user);
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+            HttpSession session = mock(HttpSession.class);
+
+            when(refreshTokenRepository.findByToken("valid-token")).thenReturn(Optional.of(refreshToken));
+            when(request.getSession(false)).thenReturn(session);
+
+            authService.logout(user, "valid-token", request, response);
+
+            verify(session).invalidate();
+        }
+    }
+
+    @Nested
+    @DisplayName("logoutAll")
+    class LogoutAll {
+
+        @Test
+        @DisplayName("모든 토큰을 삭제하고 쿠키를 정리한다")
+        void should_deleteAllTokensAndClearCookies() {
+            User user = mock(User.class);
+            when(user.getUsername()).thenReturn("testuser");
+            HttpServletRequest request = mock(HttpServletRequest.class);
+            HttpServletResponse response = mock(HttpServletResponse.class);
+
+            when(request.getSession(false)).thenReturn(null);
+
+            authService.logoutAll(user, request, response);
+
+            verify(refreshTokenRepository).deleteAllByUser(user);
+            verify(authCookieManager).clearAccessTokenCookie(response);
+            verify(authCookieManager).clearRefreshTokenCookie(response);
+        }
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,72 @@
+package com.gitranker.api.domain.auth.service;
+
+import com.gitranker.api.domain.auth.RefreshToken;
+import com.gitranker.api.domain.auth.RefreshTokenRepository;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.global.auth.jwt.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private JwtProvider jwtProvider;
+
+    private User createUser() {
+        return User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("토큰 발급 시 기존 토큰을 삭제하고 새 토큰을 저장한다")
+    void should_deleteOldAndSaveNew_when_issuingToken() {
+        User user = createUser();
+        when(jwtProvider.createRefreshToken()).thenReturn("new-token-value");
+        when(jwtProvider.calculateRefreshTokenExpiry()).thenReturn(LocalDateTime.now().plusDays(7));
+
+        String tokenValue = refreshTokenService.issueRefreshToken(user);
+
+        assertThat(tokenValue).isEqualTo("new-token-value");
+        verify(refreshTokenRepository).deleteAllByUser(user);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("저장되는 토큰에 올바른 사용자와 만료 시간이 설정된다")
+    void should_setCorrectUserAndExpiry_when_saving() {
+        User user = createUser();
+        LocalDateTime expiry = LocalDateTime.now().plusDays(7);
+        when(jwtProvider.createRefreshToken()).thenReturn("token-123");
+        when(jwtProvider.calculateRefreshTokenExpiry()).thenReturn(expiry);
+
+        refreshTokenService.issueRefreshToken(user);
+
+        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository).save(captor.capture());
+
+        RefreshToken savedToken = captor.getValue();
+        assertThat(savedToken.getToken()).isEqualTo("token-123");
+        assertThat(savedToken.getUser()).isEqualTo(user);
+        assertThat(savedToken.getExpiresAt()).isEqualTo(expiry);
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/badge/BadgeServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/badge/BadgeServiceTest.java
@@ -1,0 +1,104 @@
+package com.gitranker.api.domain.badge;
+
+import com.gitranker.api.domain.log.ActivityLog;
+import com.gitranker.api.domain.log.ActivityLogRepository;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.Tier;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.domain.user.UserRepository;
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.BusinessException;
+import com.gitranker.api.global.metrics.BusinessMetrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BadgeServiceTest {
+
+    @InjectMocks
+    private BadgeService badgeService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private ActivityLogRepository activityLogRepository;
+    @Mock private SvgBadgeRenderer svgBadgeRenderer;
+    @Mock private BusinessMetrics businessMetrics;
+
+    @Test
+    @DisplayName("사용자가 존재하면 SVG 뱃지를 생성한다")
+    void should_generateBadge_when_userExists() {
+        User user = User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        ActivityLog activityLog = ActivityLog.empty(user, LocalDate.now());
+
+        when(userRepository.findByNodeId("node1")).thenReturn(Optional.of(user));
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(activityLog);
+        when(svgBadgeRenderer.render(eq(user), eq(Tier.IRON), eq(activityLog))).thenReturn("<svg>badge</svg>");
+
+        String badge = badgeService.generateBadge("node1");
+
+        assertThat(badge).isEqualTo("<svg>badge</svg>");
+        verify(businessMetrics).incrementBadgeViews();
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않으면 USER_NOT_FOUND 예외가 발생한다")
+    void should_throwUserNotFound_when_nodeIdInvalid() {
+        when(userRepository.findByNodeId("invalid")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> badgeService.generateBadge("invalid"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                        .isEqualTo(ErrorType.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("활동 로그가 없으면 빈 로그로 뱃지를 생성한다")
+    void should_useEmptyLog_when_noActivityLogExists() {
+        User user = User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+
+        when(userRepository.findByNodeId("node1")).thenReturn(Optional.of(user));
+        when(activityLogRepository.getTopByUserOrderByActivityDateDesc(user)).thenReturn(null);
+        when(svgBadgeRenderer.render(eq(user), eq(Tier.IRON), any(ActivityLog.class))).thenReturn("<svg/>");
+
+        String badge = badgeService.generateBadge("node1");
+
+        assertThat(badge).isNotNull();
+        verify(svgBadgeRenderer).render(eq(user), eq(Tier.IRON), any(ActivityLog.class));
+    }
+
+    @Test
+    @DisplayName("티어별 미리보기 뱃지를 생성한다")
+    void should_generatePreviewBadge_when_tierProvided() {
+        when(svgBadgeRenderer.render(any(User.class), eq(Tier.DIAMOND), any(ActivityLog.class)))
+                .thenReturn("<svg>diamond</svg>");
+
+        String badge = badgeService.generateBadgeByTier(Tier.DIAMOND);
+
+        assertThat(badge).isEqualTo("<svg>diamond</svg>");
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/ranking/RankingRecalculationServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/ranking/RankingRecalculationServiceTest.java
@@ -1,0 +1,50 @@
+package com.gitranker.api.domain.ranking;
+
+import com.gitranker.api.domain.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RankingRecalculationServiceTest {
+
+    @InjectMocks
+    private RankingRecalculationService rankingRecalculationService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private RankingService rankingService;
+
+    @Test
+    @DisplayName("첫 호출 시 랭킹을 재산정한다")
+    void should_recalculate_when_calledFirstTime() {
+        boolean result = rankingRecalculationService.recalculateIfNeeded();
+
+        assertThat(result).isTrue();
+        verify(userRepository).bulkUpdateRanking();
+        verify(rankingService).evictRankingCache();
+    }
+
+    @Test
+    @DisplayName("연속 호출 시 디바운스로 두 번째 호출을 건너뛴다")
+    void should_skipRecalculation_when_calledImmediatelyAgain() {
+        rankingRecalculationService.recalculateIfNeeded(); // 첫 번째: 실행
+        boolean result = rankingRecalculationService.recalculateIfNeeded(); // 두 번째: 건너뜀
+
+        assertThat(result).isFalse();
+        verify(userRepository, times(1)).bulkUpdateRanking(); // 1번만 호출
+    }
+
+    @Test
+    @DisplayName("재산정 완료 후 랭킹 캐시를 무효화한다")
+    void should_evictCache_when_recalculationCompleted() {
+        rankingRecalculationService.recalculateIfNeeded();
+
+        verify(rankingService).evictRankingCache();
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/user/service/UserPersistenceServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/user/service/UserPersistenceServiceTest.java
@@ -1,0 +1,107 @@
+package com.gitranker.api.domain.user.service;
+
+import com.gitranker.api.domain.log.ActivityLogOrchestrator;
+import com.gitranker.api.domain.ranking.RankingRecalculationService;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.domain.user.UserRepository;
+import com.gitranker.api.domain.user.vo.ActivityStatistics;
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserPersistenceServiceTest {
+
+    @InjectMocks
+    private UserPersistenceService userPersistenceService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private ActivityLogOrchestrator activityLogOrchestrator;
+    @Mock private RankingRecalculationService rankingRecalculationService;
+
+    private User createUser() {
+        return User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("신규 사용자 저장 시 랭킹 정보를 계산하고 활동 로그를 생성한다")
+    void should_calculateRankingAndCreateLogs_when_savingNewUser() {
+        User user = createUser();
+        ActivityStatistics totalStats = ActivityStatistics.of(50, 10, 5, 3, 8);
+        ActivityStatistics baselineStats = ActivityStatistics.empty();
+
+        when(userRepository.countByScoreValueGreaterThan(anyInt())).thenReturn(0L);
+        when(userRepository.count()).thenReturn(0L);
+        when(userRepository.save(user)).thenReturn(user);
+
+        User result = userPersistenceService.saveNewUser(user, totalStats, baselineStats);
+
+        assertThat(result.getTotalScore()).isGreaterThan(0);
+        verify(userRepository).save(user);
+        verify(activityLogOrchestrator).createLogsForNewUser(user, totalStats, baselineStats);
+        verify(rankingRecalculationService).recalculateIfNeeded();
+    }
+
+    @Test
+    @DisplayName("통계 업데이트 시 사용자가 존재하지 않으면 예외가 발생한다")
+    void should_throwUserNotFound_when_userDoesNotExist() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userPersistenceService.updateUserStatisticsWithLog(
+                999L, ActivityStatistics.empty(), ActivityStatistics.empty()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                        .isEqualTo(ErrorType.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("통계 업데이트 시 점수와 랭킹을 갱신하고 fullScan을 기록한다")
+    void should_updateStatsAndRecordFullScan_when_userExists() {
+        User user = createUser();
+        ActivityStatistics totalStats = ActivityStatistics.of(50, 10, 5, 3, 8);
+        ActivityStatistics baselineStats = ActivityStatistics.empty();
+
+        when(userRepository.findById(any())).thenReturn(Optional.of(user));
+        when(userRepository.countByScoreValueGreaterThan(anyInt())).thenReturn(0L);
+        when(userRepository.count()).thenReturn(1L);
+
+        User result = userPersistenceService.updateUserStatisticsWithLog(
+                user.getId(), totalStats, baselineStats);
+
+        assertThat(result.getTotalScore()).isGreaterThan(0);
+        verify(activityLogOrchestrator).updateLogsForRefresh(user, totalStats, baselineStats);
+        verify(rankingRecalculationService).recalculateIfNeeded();
+    }
+
+    @Test
+    @DisplayName("프로필 업데이트 후 저장한다")
+    void should_saveUser_when_profileUpdated() {
+        User user = createUser();
+        when(userRepository.save(user)).thenReturn(user);
+
+        User result = userPersistenceService.updateProfile(user, "newname", "https://new.img");
+
+        assertThat(result.getUsername()).isEqualTo("newname");
+        verify(userRepository).save(user);
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/user/service/UserRefreshServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/user/service/UserRefreshServiceTest.java
@@ -1,0 +1,129 @@
+package com.gitranker.api.domain.user.service;
+
+import com.gitranker.api.domain.log.ActivityLog;
+import com.gitranker.api.domain.log.ActivityLogService;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.domain.user.UserRepository;
+import com.gitranker.api.domain.user.dto.RegisterUserResponse;
+import com.gitranker.api.domain.user.vo.ActivityStatistics;
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.BusinessException;
+import com.gitranker.api.global.metrics.BusinessMetrics;
+import com.gitranker.api.infrastructure.github.GitHubActivityService;
+import com.gitranker.api.infrastructure.github.GitHubDataMapper;
+import com.gitranker.api.infrastructure.github.dto.GitHubAllActivitiesResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserRefreshServiceTest {
+
+    @InjectMocks
+    private UserRefreshService userRefreshService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private UserPersistenceService userPersistenceService;
+    @Mock private ActivityLogService activityLogService;
+    @Mock private GitHubActivityService gitHubActivityService;
+    @Mock private GitHubDataMapper gitHubDataMapper;
+    @Mock private BaselineStatsCalculator baselineStatsCalculator;
+    @Mock private BusinessMetrics businessMetrics;
+
+    private User createUserWithCooldownExpired() {
+        User user = User.builder()
+                .githubId(1L)
+                .nodeId("node1")
+                .username("testuser")
+                .email("test@test.com")
+                .profileImage("https://img.com/1")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        // 쿨다운을 통과시키기 위해 recordFullScan 시간을 과거로 맞출 수 없으므로
+        // canTriggerFullScan이 false를 반환하는 것은 별도 테스트에서 검증
+        return user;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 새로고침하면 USER_NOT_FOUND 예외가 발생한다")
+    void should_throwUserNotFound_when_usernameDoesNotExist() {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userRefreshService.refresh("unknown"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                        .isEqualTo(ErrorType.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("쿨다운 중이면 REFRESH_COOL_DOWN_EXCEEDED 예외가 발생한다")
+    void should_throwCooldownExceeded_when_refreshedRecently() {
+        // 방금 생성된 User는 lastFullScanAt=now()이므로 쿨다운 상태
+        User user = createUserWithCooldownExpired();
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userRefreshService.refresh("testuser"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorType())
+                        .isEqualTo(ErrorType.REFRESH_COOL_DOWN_EXCEEDED));
+
+        verify(gitHubActivityService, never()).fetchRawAllActivities(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("새로고침 성공 시 GitHub API를 호출하고 응답을 반환한다")
+    void should_fetchGitHubDataAndReturnResponse_when_cooldownPassed() {
+        User user = mock(User.class);
+        when(user.canTriggerFullScan()).thenReturn(true);
+        when(user.getGithubCreatedAt()).thenReturn(LocalDateTime.of(2020, 1, 1, 0, 0));
+        when(user.getId()).thenReturn(1L);
+        when(user.getTotalScore()).thenReturn(0);
+
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+
+        GitHubAllActivitiesResponse rawResponse = mock(GitHubAllActivitiesResponse.class);
+        when(gitHubActivityService.fetchRawAllActivities(eq("testuser"), any())).thenReturn(rawResponse);
+
+        ActivityStatistics totalStats = ActivityStatistics.of(50, 10, 5, 3, 8);
+        ActivityStatistics baselineStats = ActivityStatistics.of(10, 2, 1, 0, 2);
+        when(gitHubDataMapper.toActivityStatistics(rawResponse)).thenReturn(totalStats);
+        when(baselineStatsCalculator.calculate(user, rawResponse)).thenReturn(baselineStats);
+
+        User updatedUser = mock(User.class);
+        when(updatedUser.getUsername()).thenReturn("testuser");
+        when(updatedUser.getTotalScore()).thenReturn(100);
+        when(updatedUser.getTier()).thenReturn(com.gitranker.api.domain.user.Tier.IRON);
+        when(updatedUser.getRanking()).thenReturn(1);
+        when(updatedUser.getPercentile()).thenReturn(50.0);
+        when(updatedUser.getRole()).thenReturn(Role.USER);
+
+        when(userPersistenceService.updateUserStatisticsWithLog(eq(1L), eq(totalStats), eq(baselineStats)))
+                .thenReturn(updatedUser);
+
+        ActivityLog activityLog = ActivityLog.empty(updatedUser, LocalDate.now());
+        when(activityLogService.getLatestLog(updatedUser)).thenReturn(activityLog);
+
+        RegisterUserResponse response = userRefreshService.refresh("testuser");
+
+        assertThat(response).isNotNull();
+        verify(gitHubActivityService).fetchRawAllActivities(eq("testuser"), any());
+        verify(userPersistenceService).updateUserStatisticsWithLog(eq(1L), eq(totalStats), eq(baselineStats));
+        verify(businessMetrics).incrementRefreshes();
+    }
+}

--- a/src/test/java/com/gitranker/api/domain/user/service/UserRegistrationServiceTest.java
+++ b/src/test/java/com/gitranker/api/domain/user/service/UserRegistrationServiceTest.java
@@ -1,0 +1,167 @@
+package com.gitranker.api.domain.user.service;
+
+import com.gitranker.api.domain.log.ActivityLog;
+import com.gitranker.api.domain.log.ActivityLogService;
+import com.gitranker.api.domain.user.Role;
+import com.gitranker.api.domain.user.User;
+import com.gitranker.api.domain.user.UserRepository;
+import com.gitranker.api.domain.user.dto.RegisterUserResponse;
+import com.gitranker.api.domain.user.vo.ActivityStatistics;
+import com.gitranker.api.global.auth.OAuthAttributes;
+import com.gitranker.api.global.metrics.BusinessMetrics;
+import com.gitranker.api.infrastructure.github.GitHubActivityService;
+import com.gitranker.api.infrastructure.github.GitHubDataMapper;
+import com.gitranker.api.infrastructure.github.dto.GitHubAllActivitiesResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserRegistrationServiceTest {
+
+    @InjectMocks
+    private UserRegistrationService userRegistrationService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private UserPersistenceService userPersistenceService;
+    @Mock private ActivityLogService activityLogService;
+    @Mock private GitHubActivityService gitHubActivityService;
+    @Mock private GitHubDataMapper gitHubDataMapper;
+    @Mock private BaselineStatsCalculator baselineStatsCalculator;
+    @Mock private BusinessMetrics businessMetrics;
+
+    private OAuthAttributes createOAuthAttributes(String username) {
+        Map<String, Object> attrs = Map.of(
+                "id", 12345,
+                "node_id", "MDQ6VXNlcjEyMzQ1",
+                "login", username,
+                "email", "test@test.com",
+                "avatar_url", "https://img.com/1",
+                "created_at", "2020-01-01T00:00:00Z"
+        );
+        return OAuthAttributes.of("id", attrs);
+    }
+
+    @Test
+    @DisplayName("신규 사용자이면 GitHub 데이터를 수집하고 저장한다")
+    void should_fetchGitHubDataAndSave_when_newUser() {
+        OAuthAttributes attributes = createOAuthAttributes("newuser");
+        when(userRepository.findByNodeId("MDQ6VXNlcjEyMzQ1")).thenReturn(Optional.empty());
+
+        GitHubAllActivitiesResponse rawResponse = mock(GitHubAllActivitiesResponse.class);
+        when(gitHubActivityService.fetchRawAllActivities(eq("newuser"), any())).thenReturn(rawResponse);
+
+        ActivityStatistics totalStats = ActivityStatistics.of(10, 2, 1, 0, 3);
+        ActivityStatistics baselineStats = ActivityStatistics.empty();
+        when(gitHubDataMapper.toActivityStatistics(rawResponse)).thenReturn(totalStats);
+        when(baselineStatsCalculator.calculate(any(User.class), eq(rawResponse))).thenReturn(baselineStats);
+
+        User savedUser = User.builder()
+                .githubId(12345L)
+                .nodeId("MDQ6VXNlcjEyMzQ1")
+                .username("newuser")
+                .email("test@test.com")
+                .profileImage("https://img.com/1")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        when(userPersistenceService.saveNewUser(any(User.class), eq(totalStats), eq(baselineStats)))
+                .thenReturn(savedUser);
+
+        ActivityLog activityLog = ActivityLog.empty(savedUser, LocalDate.now());
+        when(activityLogService.findLatestLog(savedUser)).thenReturn(Optional.of(activityLog));
+
+        RegisterUserResponse response = userRegistrationService.register(attributes);
+
+        assertThat(response).isNotNull();
+        assertThat(response.isNewUser()).isTrue();
+        verify(gitHubActivityService).fetchRawAllActivities(eq("newuser"), any());
+        verify(userPersistenceService).saveNewUser(any(User.class), eq(totalStats), eq(baselineStats));
+        verify(businessMetrics).incrementRegistrations();
+    }
+
+    @Test
+    @DisplayName("기존 사용자이면 GitHub 데이터를 수집하지 않고 기존 정보를 반환한다")
+    void should_returnExisting_when_userAlreadyExists() {
+        OAuthAttributes attributes = createOAuthAttributes("existinguser");
+
+        User existingUser = User.builder()
+                .githubId(12345L)
+                .nodeId("MDQ6VXNlcjEyMzQ1")
+                .username("existinguser")
+                .email("test@test.com")
+                .profileImage("https://img.com/1")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        when(userRepository.findByNodeId("MDQ6VXNlcjEyMzQ1")).thenReturn(Optional.of(existingUser));
+
+        ActivityLog activityLog = ActivityLog.empty(existingUser, LocalDate.now());
+        when(activityLogService.findLatestLog(existingUser)).thenReturn(Optional.of(activityLog));
+
+        RegisterUserResponse response = userRegistrationService.register(attributes);
+
+        assertThat(response).isNotNull();
+        assertThat(response.isNewUser()).isFalse();
+        verify(gitHubActivityService, never()).fetchRawAllActivities(anyString(), any());
+        verify(businessMetrics, never()).incrementRegistrations();
+    }
+
+    @Test
+    @DisplayName("기존 사용자의 프로필이 변경되었으면 업데이트한다")
+    void should_updateProfile_when_existingUserInfoChanged() {
+        Map<String, Object> attrs = Map.of(
+                "id", 12345,
+                "node_id", "MDQ6VXNlcjEyMzQ1",
+                "login", "newname",
+                "email", "test@test.com",
+                "avatar_url", "https://img.com/new",
+                "created_at", "2020-01-01T00:00:00Z"
+        );
+        OAuthAttributes attributes = OAuthAttributes.of("id", attrs);
+
+        User existingUser = User.builder()
+                .githubId(12345L)
+                .nodeId("MDQ6VXNlcjEyMzQ1")
+                .username("oldname")
+                .email("test@test.com")
+                .profileImage("https://img.com/old")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        when(userRepository.findByNodeId("MDQ6VXNlcjEyMzQ1")).thenReturn(Optional.of(existingUser));
+
+        User updatedUser = User.builder()
+                .githubId(12345L)
+                .nodeId("MDQ6VXNlcjEyMzQ1")
+                .username("newname")
+                .email("test@test.com")
+                .profileImage("https://img.com/new")
+                .githubCreatedAt(LocalDateTime.of(2020, 1, 1, 0, 0))
+                .role(Role.USER)
+                .build();
+        when(userPersistenceService.updateProfile(existingUser, "newname", "https://img.com/new"))
+                .thenReturn(updatedUser);
+
+        ActivityLog activityLog = ActivityLog.empty(updatedUser, LocalDate.now());
+        when(activityLogService.findLatestLog(updatedUser)).thenReturn(Optional.of(activityLog));
+
+        RegisterUserResponse response = userRegistrationService.register(attributes);
+
+        assertThat(response.username()).isEqualTo("newname");
+        verify(userPersistenceService).updateProfile(existingUser, "newname", "https://img.com/new");
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #50

## 변경 사항
Mockito 기반 서비스 레이어 단위 테스트 8개 파일, 31개 테스트 케이스 추가

### 테스트 대상 및 주요 검증 항목
- **AuthService (7건)**: 유효한 토큰 갱신, 만료/무효 토큰 예외, 로그아웃 소유권 검증, 세션 무효화, 전체 로그아웃
- **RefreshTokenService (2건)**: 기존 토큰 삭제 후 새 토큰 저장, ArgumentCaptor로 저장 객체의 값 검증
- **UserRefreshService (3건)**: 존재하지 않는 사용자 예외, 쿨다운 초과 예외, GitHub API 호출 후 응답 반환
- **UserRegistrationService (3건)**: 신규 사용자 등록, 기존 사용자 반환, 프로필 변경 감지 시 업데이트
- **UserPersistenceService (4건)**: 신규 저장 후 랭킹 재산정, 존재하지 않는 사용자 예외, 통계/프로필 갱신
- **RankingRecalculationService (3건)**: 첫 호출 시 재산정 실행, 연속 호출 디바운스, 캐시 무효화
- **BadgeService (4건)**: 정상 뱃지 생성, 사용자 미존재 예외, 빈 로그 대체, 티어 미리보기
- **ScoreRecalculationProcessor (5건)**: Full/Incremental 전략 선택, Retryable/NonRetryable 예외 전파, 일반 예외 BusinessException 래핑

### 테스트 설계 원칙
- Mockito strict stubbing 준수: 각 테스트에서 실제 호출되는 메서드만 stubbing하여 불필요한 stub 방지
- 외부 의존성 완전 격리: Repository, GitHub API, JwtProvider 등 모두 Mock 처리
- 검증 대상 명확화: 반환값 검증, 예외 타입/에러코드 검증, 메서드 호출 여부/횟수 검증을 목적에 맞게 사용

## 테스트 결과
```
106 tests, 0 failures, 0 ignored (1.021s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 여러 핵심 서비스에 대한 포괄적인 단위 테스트 추가
  * 정상 동작, 오류 처리, 엣지 케이스 등 다양한 시나리오 검증으로 코드 품질 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->