### PR TITLE
[Feat]: GitHub API 인프라 단위 테스트 추가

### DIFF
--- a/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiErrorHandlerTest.java
+++ b/src/test/java/com/gitranker/api/infrastructure/github/GitHubApiErrorHandlerTest.java
@@ -1,0 +1,252 @@
+package com.gitranker.api.infrastructure.github;
+
+import com.gitranker.api.global.error.ErrorType;
+import com.gitranker.api.global.error.exception.GitHubApiNonRetryableException;
+import com.gitranker.api.global.error.exception.GitHubApiRetryableException;
+import com.gitranker.api.global.error.exception.GitHubRateLimitException;
+import io.netty.handler.timeout.ReadTimeoutException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubApiErrorHandlerTest {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private GitHubApiMetrics apiMetrics;
+
+    @InjectMocks
+    private GitHubApiErrorHandler errorHandler;
+
+    /**
+     * @InjectMocks는 appZoneId(ZoneId)를 주입하지 못하므로 직접 생성한다.
+     */
+    private GitHubApiErrorHandler createHandler() {
+        return new GitHubApiErrorHandler(ZONE, apiMetrics);
+    }
+
+    @Nested
+    @DisplayName("handleHttpStatus")
+    class HandleHttpStatus {
+
+        @Test
+        @DisplayName("403 응답이면 GitHubRateLimitException을 반환한다")
+        void should_returnRateLimitException_when_status403() {
+            GitHubApiErrorHandler handler = createHandler();
+            long resetEpoch = Instant.now().plusSeconds(3600).getEpochSecond();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.FORBIDDEN)
+                    .header("x-ratelimit-reset", String.valueOf(resetEpoch))
+                    .build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isInstanceOf(GitHubRateLimitException.class);
+            GitHubRateLimitException rateLimitEx = (GitHubRateLimitException) result;
+            assertThat(rateLimitEx.getResetAt()).isNotNull();
+            verify(apiMetrics).recordRateLimitExceeded();
+        }
+
+        @Test
+        @DisplayName("429 응답이면 GitHubRateLimitException을 반환한다")
+        void should_returnRateLimitException_when_status429() {
+            GitHubApiErrorHandler handler = createHandler();
+            long resetEpoch = Instant.now().plusSeconds(3600).getEpochSecond();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.TOO_MANY_REQUESTS)
+                    .header("x-ratelimit-reset", String.valueOf(resetEpoch))
+                    .build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isInstanceOf(GitHubRateLimitException.class);
+            verify(apiMetrics).recordRateLimitExceeded();
+        }
+
+        @Test
+        @DisplayName("403 응답에 reset 헤더가 없으면 현재 시간 + 60분으로 fallback한다")
+        void should_fallbackResetTime_when_noResetHeader() {
+            GitHubApiErrorHandler handler = createHandler();
+            LocalDateTime before = LocalDateTime.now(ZONE).plusMinutes(59);
+
+            ClientResponse response = ClientResponse.create(HttpStatus.FORBIDDEN).build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isInstanceOf(GitHubRateLimitException.class);
+            GitHubRateLimitException rateLimitEx = (GitHubRateLimitException) result;
+            assertThat(rateLimitEx.getResetAt()).isAfter(before);
+        }
+
+        @Test
+        @DisplayName("4xx 응답(403 제외)이면 CLIENT_ERROR 타입의 RetryableException을 반환한다")
+        void should_returnClientError_when_status4xx() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.BAD_REQUEST).build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isInstanceOf(GitHubApiRetryableException.class);
+            GitHubApiRetryableException retryableEx = (GitHubApiRetryableException) result;
+            assertThat(retryableEx.getErrorType()).isEqualTo(ErrorType.GITHUB_API_CLIENT_ERROR);
+            verify(apiMetrics).recordFailure();
+        }
+
+        @Test
+        @DisplayName("5xx 응답이면 SERVER_ERROR 타입의 RetryableException을 반환한다")
+        void should_returnServerError_when_status5xx() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.INTERNAL_SERVER_ERROR).build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isInstanceOf(GitHubApiRetryableException.class);
+            GitHubApiRetryableException retryableEx = (GitHubApiRetryableException) result;
+            assertThat(retryableEx.getErrorType()).isEqualTo(ErrorType.GITHUB_API_SERVER_ERROR);
+            verify(apiMetrics).recordFailure();
+        }
+
+        @Test
+        @DisplayName("2xx 응답이면 null을 반환한다")
+        void should_returnNull_when_status2xx() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            ClientResponse response = ClientResponse.create(HttpStatus.OK).build();
+
+            RuntimeException result = handler.handleHttpStatus(response);
+
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("handleGraphQLErrors")
+    class HandleGraphQLErrors {
+
+        @Test
+        @DisplayName("에러 리스트가 null이면 예외를 던지지 않는다")
+        void should_doNothing_when_errorsNull() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            handler.handleGraphQLErrors(null);
+            // 예외 없이 정상 종료
+        }
+
+        @Test
+        @DisplayName("에러 리스트가 비어있으면 예외를 던지지 않는다")
+        void should_doNothing_when_errorsEmpty() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            handler.handleGraphQLErrors(Collections.emptyList());
+            // 예외 없이 정상 종료
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없는 에러면 NonRetryableException을 던진다")
+        void should_throwNonRetryable_when_userNotFound() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            List<Object> errors = List.of("Could not resolve to a User with the login of 'unknown'");
+
+            assertThatThrownBy(() -> handler.handleGraphQLErrors(errors))
+                    .isInstanceOf(GitHubApiNonRetryableException.class)
+                    .extracting(e -> ((GitHubApiNonRetryableException) e).getErrorType())
+                    .isEqualTo(ErrorType.GITHUB_USER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("기타 GraphQL 에러면 PARTIAL_ERROR 타입의 RetryableException을 던진다")
+        void should_throwRetryable_when_otherGraphQLError() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            List<Object> errors = List.of("Something went wrong");
+
+            assertThatThrownBy(() -> handler.handleGraphQLErrors(errors))
+                    .isInstanceOf(GitHubApiRetryableException.class)
+                    .extracting(e -> ((GitHubApiRetryableException) e).getErrorType())
+                    .isEqualTo(ErrorType.GITHUB_PARTIAL_ERROR);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleTimeout / handleReadTimeout / handleIOException / handleNetworkError")
+    class HandleOtherErrors {
+
+        @Test
+        @DisplayName("TimeoutException이면 TIMEOUT 타입의 RetryableException을 반환한다")
+        void should_returnTimeout_when_timeoutException() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            GitHubApiRetryableException result = handler.handleTimeout(
+                    new TimeoutException("timed out"), Duration.ofSeconds(30));
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.GITHUB_API_TIMEOUT);
+            assertThat(result.getCause()).isInstanceOf(TimeoutException.class);
+        }
+
+        @Test
+        @DisplayName("ReadTimeoutException이면 TIMEOUT 타입의 RetryableException을 반환한다")
+        void should_returnTimeout_when_readTimeoutException() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            GitHubApiRetryableException result = handler.handleReadTimeout(
+                    ReadTimeoutException.INSTANCE);
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.GITHUB_API_TIMEOUT);
+        }
+
+        @Test
+        @DisplayName("IOException이면 API_ERROR 타입의 RetryableException을 반환한다")
+        void should_returnApiError_when_ioException() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            GitHubApiRetryableException result = handler.handleIOException(
+                    new IOException("connection reset"));
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.GITHUB_API_ERROR);
+            assertThat(result.getCause()).isInstanceOf(IOException.class);
+        }
+
+        @Test
+        @DisplayName("WebClientRequestException이면 API_ERROR 타입의 RetryableException을 반환한다")
+        void should_returnApiError_when_networkError() {
+            GitHubApiErrorHandler handler = createHandler();
+
+            WebClientRequestException networkEx = new WebClientRequestException(
+                    new IOException("connection refused"),
+                    org.springframework.http.HttpMethod.POST,
+                    URI.create("https://api.github.com/graphql"),
+                    org.springframework.http.HttpHeaders.EMPTY);
+
+            GitHubApiRetryableException result = handler.handleNetworkError(networkEx);
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.GITHUB_API_ERROR);
+            assertThat(result.getCause()).isInstanceOf(WebClientRequestException.class);
+        }
+    }
+}

--- a/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java
+++ b/src/test/java/com/gitranker/api/infrastructure/github/token/GitHubTokenPoolTest.java
@@ -1,0 +1,97 @@
+package com.gitranker.api.infrastructure.github.token;
+
+import com.gitranker.api.global.error.exception.GitHubRateLimitExhaustedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHubTokenPoolTest {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final int THRESHOLD = 10;
+
+    private GitHubTokenPool createPool(String tokensConfig) {
+        return new GitHubTokenPool(tokensConfig, THRESHOLD, ZONE);
+    }
+
+    @Test
+    @DisplayName("단일 토큰 설정 시 해당 토큰을 반환한다")
+    void should_returnToken_when_singleTokenConfigured() {
+        GitHubTokenPool pool = createPool("ghp_token1");
+
+        assertThat(pool.getToken()).isEqualTo("ghp_token1");
+    }
+
+    @Test
+    @DisplayName("쉼표로 구분된 여러 토큰을 파싱한다")
+    void should_returnFirstToken_when_multipleTokensConfigured() {
+        GitHubTokenPool pool = createPool("ghp_token1, ghp_token2, ghp_token3");
+
+        assertThat(pool.getToken()).isEqualTo("ghp_token1");
+    }
+
+    @Test
+    @DisplayName("빈 토큰 설정이면 예외가 발생한다")
+    void should_throwException_when_tokensConfigIsBlank() {
+        assertThatThrownBy(() -> createPool(""))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("null 토큰 설정이면 예외가 발생한다")
+    void should_throwException_when_tokensConfigIsNull() {
+        assertThatThrownBy(() -> new GitHubTokenPool(null, THRESHOLD, ZONE))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("현재 토큰이 Rate Limit에 걸리면 다음 토큰으로 로테이션한다")
+    void should_rotateToNextToken_when_currentTokenRateLimited() {
+        GitHubTokenPool pool = createPool("ghp_token1, ghp_token2");
+
+        // token1의 remaining을 threshold 이하로 설정 → 사용 불가
+        pool.updateTokenState("ghp_token1", 5, LocalDateTime.now(ZONE).plusHours(1));
+
+        assertThat(pool.getToken()).isEqualTo("ghp_token2");
+    }
+
+    @Test
+    @DisplayName("모든 토큰이 소진되면 GitHubRateLimitExhaustedException이 발생한다")
+    void should_throwExhausted_when_allTokensRateLimited() {
+        GitHubTokenPool pool = createPool("ghp_token1, ghp_token2");
+
+        pool.updateTokenState("ghp_token1", 5, LocalDateTime.now(ZONE).plusHours(1));
+        pool.updateTokenState("ghp_token2", 3, LocalDateTime.now(ZONE).plusHours(1));
+
+        assertThatThrownBy(pool::getToken)
+                .isInstanceOf(GitHubRateLimitExhaustedException.class);
+    }
+
+    @Test
+    @DisplayName("토큰 상태 갱신 후에도 remaining이 threshold보다 크면 사용 가능하다")
+    void should_remainAvailable_when_remainingAboveThreshold() {
+        GitHubTokenPool pool = createPool("ghp_token1");
+
+        pool.updateTokenState("ghp_token1", 100, LocalDateTime.now(ZONE).plusHours(1));
+
+        assertThat(pool.getToken()).isEqualTo("ghp_token1");
+    }
+
+    @Test
+    @DisplayName("로테이션 후 다시 요청하면 마지막으로 사용한 토큰부터 탐색한다")
+    void should_startFromLastUsedIndex_when_gettingTokenAfterRotation() {
+        GitHubTokenPool pool = createPool("ghp_token1, ghp_token2, ghp_token3");
+
+        // token1 소진 → token2로 로테이션
+        pool.updateTokenState("ghp_token1", 5, LocalDateTime.now(ZONE).plusHours(1));
+        assertThat(pool.getToken()).isEqualTo("ghp_token2");
+
+        // 다음 호출도 token2부터 시작 (token2가 아직 사용 가능하므로 token2 반환)
+        assertThat(pool.getToken()).isEqualTo("ghp_token2");
+    }
+}


### PR DESCRIPTION
## Summary
- GitHubTokenPool 단위 테스트 8개: 토큰 파싱, 로테이션, 소진 시 예외, 상태 갱신, 인덱스 추적
- GitHubApiErrorHandler 단위 테스트 16개: HTTP 상태별 예외 분류(403/429/4xx/5xx/2xx), GraphQL 에러 처리(USER_NOT_FOUND/PARTIAL_ERROR), 타임아웃·IO·네트워크 에러 처리

핵심 로직(토큰 관리, 에러 분류)은 별도 클래스로 분리되어 있어 외부 의존 없는 순수 단위 테스트로 작성했습니다.

Closes #54

## Test plan
- [x] `./gradlew test` — 전체 128개 단위 테스트 통과
- [ ] CI 파이프라인 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * GitHub API 에러 처리 및 토큰 풀 관리 기능에 대한 포괄적인 단위 테스트 추가되었습니다. 속도 제한, 타임아웃, 네트워크 오류 등 다양한 시나리오를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->