### PR TITLE
백엔드 build 전용 검증 기준 정렬

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   verify:
-    name: Unit and Integration Verification
+    name: Build Verification
     runs-on: ubuntu-latest
 
     steps:
@@ -29,11 +29,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run unit tests
-        run: ./gradlew test
-
-      - name: Run integration tests
-        run: ./gradlew integrationTest
-
       - name: Run packaging build
-        run: ./gradlew build -x test
+        run: ./gradlew build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   verify:
-    name: Pre-deploy Verification
+    name: Pre-deploy Build Verification
     runs-on: ubuntu-latest
 
     steps:
@@ -30,14 +30,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run unit tests
-        run: ./gradlew test
-
-      - name: Run integration tests
-        run: ./gradlew integrationTest
-
       - name: Run packaging build
-        run: ./gradlew build -x test
+        run: ./gradlew build
 
   docker:
     name: Build & Push Docker Image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,7 @@
 1. `README.md`에서 프로젝트 목적과 high-level overview를 확인한다.
 2. `build.gradle`, `settings.gradle`에서 모듈 구조, 의존성, verification task를 확인한다.
 3. `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`에서 CI verification lane과 pre-deploy gate를 확인한다.
-4. `src/test/java/`에서 current verification slice를 본다.
-   - `*IT.java`는 Testcontainers 기반 integration lane이다.
+4. 현재 `src/test/` tree는 baseline reset 상태이므로, follow-up verification rebuild 전까지는 `build.gradle`과 workflow가 retained build-only lane을 어떻게 고정하는지 먼저 본다.
 5. `src/main/java/`, `src/main/resources/`에서 실제 구현과 runtime config를 읽는다.
 
 ## Source Of Truth
@@ -16,15 +15,14 @@
 - repo overview: `README.md`
 - build and verification entrypoint: `build.gradle`
 - CI / deploy gate: `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`
-- backend behavior and contracts: `src/main/java/`, `src/test/java/`
+- backend behavior and contracts: `src/main/java/`, `src/main/resources/`
 - runtime container surface: `Dockerfile`, `docker-compose.yml`
 
 ## 운영 원칙
 
 - backend 구현 세부사항은 workflow repo 문서가 아니라 이 저장소의 문서, 설정, 코드, 테스트가 canonical source다.
 - root `README.md`는 개요만 유지한다. concrete bootstrap, verification, entrypoint 설명은 `AGENTS.md`와 named entry docs가 맡는다.
-- 현재 verification baseline command set은 `./gradlew test`, `./gradlew integrationTest`, packaging check `./gradlew build`다.
-- `./gradlew build`만으로는 `integrationTest`가 실행되지 않는다. CI/deploy gate는 이 순서를 명시적으로 호출하고, workflow에서는 마지막 packaging check를 `./gradlew build -x test`로 실행해 중복 unit test를 피한다.
-- `integrationTest`는 Docker/Testcontainers 전제를 가진다. 로컬 환경에서 Docker가 없으면 CI evidence와 함께 해석한다.
+- 현재 verification baseline command set은 `./gradlew build`다.
+- current baseline에는 dedicated test/integration lane이 없다. follow-up rebuild가 필요하면 `build.gradle`, workflow YAML, `AGENTS.md`를 함께 갱신한 뒤 repo-local baseline으로 다시 도입한다.
 - verification lane이나 deploy gate를 바꾸면 `build.gradle`, workflow YAML, `AGENTS.md`를 함께 맞춘다.
 - 현재 repo-local `.codex/skills/`는 없다. 별도 skill이 없을 때는 이 문서와 nearest code/test를 먼저 읽고 진행한다.

--- a/build.gradle
+++ b/build.gradle
@@ -46,40 +46,6 @@ dependencies {
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-
-	testImplementation 'io.projectreactor:reactor-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testImplementation 'org.springframework.batch:spring-batch-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'org.testcontainers:junit-jupiter'
-	testImplementation 'org.testcontainers:mysql'
-
-	testRuntimeOnly 'com.h2database:h2'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-// 단위 테스트: *IT.java 제외 (Docker 불필요)
-tasks.named('test') {
-	useJUnitPlatform()
-	exclude '**/*IT.class'
-}
-
-// 통합 테스트: Testcontainers 기반 *IT.java만 별도 lane에서 실행
-// check 라이프사이클에는 연결하지 않고 CI/deploy verification이 명시적으로 호출한다.
-tasks.register('integrationTest', Test) {
-	group = 'verification'
-	description = 'Runs Testcontainers-backed integration tests.'
-	useJUnitPlatform()
-	include '**/*IT.class'
-
-	mustRunAfter tasks.named('test')
-
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath
-
-	// Docker 29+는 최소 API 1.44를 요구하지만 docker-java 3.4.0은 기본값 1.32로 요청함
-	systemProperty 'api.version', '1.44'
 }
 tasks.named('processResources') {
 	filteringCharset = 'UTF-8'


### PR DESCRIPTION
## 1) 요약
- legacy test/integration surface가 이미 비어 있는 backend repo에서 residual Gradle test lane과 workflow 실행 경로를 제거했습니다.
- backend verification baseline을 `./gradlew build` 기준으로 다시 잠가 repo-local build, workflow, entrypoint 문서가 같은 semantics를 보도록 맞췄습니다.

## 2) 연관 이슈
- Closes #82
- 관련 frontend 이슈/PR: 없음

## 3) 문제와 목표
- 문제: `src/test/` tree가 비어 있는데도 `build.gradle`, CI, deploy gate, `AGENTS.md`는 여전히 `test -> integrationTest -> build` 레인을 소유하고 있어 current baseline 해석이 갈렸습니다.
- 사용자/운영자 관점의 결과: backend repo만 읽어도 현재 검증 기준이 build-only baseline이라는 점을 바로 해석할 수 있습니다.
- 비목표: 새 테스트 추가, 새 CI 레인 도입, `src/main/` production 동작 변경

## 4) 영향 범위
- 변경된 패키지/모듈: `build.gradle`, `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`, `AGENTS.md`
- API/DTO/Schema 영향: 없음
- DB/Cache/Batch/Scheduler 영향: 없음
- 보안/권한 영향: 없음

## 5) 검증 증거

| 유형 | 명령어 / 증거 | 결과 |
| --- | --- | --- |
| Build | `./gradlew build` | 성공 |
| Unit | `./gradlew test` | 성공 (`NO-SOURCE`) |
| Integration | `미실행(legacy lane 제거 대상이라 현재 baseline 없음)` | 해당 없음 |
| Coverage | `미실행(current baseline scope 아님)` | 해당 없음 |
| API/Manual Smoke | `미실행(생산 동작 변경 없음)` | 해당 없음 |

## 6) 관측성 확인
- 확인한 로그: 없음
- 확인한 메트릭: 없음
- 확인한 trace/dashboard/query: 없음

## 7) AI 리뷰 메모 (선택)
- Codex: `GRB-05`, `GRB-06` close-out과 같은 diff 기준으로 latest verification을 다시 확인했습니다.
- CodeRabbitAI: 없음

## 8) 리스크 및 롤백
- 리스크: dedicated regression surface가 follow-up test/CI rebuild 전까지 비어 있습니다.
- 롤백 계획: 이 PR revert로 legacy lane 정의를 복원할 수 있지만, 실제 rebuild는 별도 spec으로 다시 잠그는 편이 맞습니다.
